### PR TITLE
完善eslint规则

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -66,6 +66,7 @@
         "jsx-a11y/no-static-element-interactions": 0,
         "jsx-a11y/no-noninteractive-element-interactions": 0,
         "jsx-a11y/alt-text": 0,
-        "jsx-a11y/click-events-have-key-events": 0
+        "jsx-a11y/click-events-have-key-events": 0,
+        "linebreak-style": ["error", "windows"]
     }
 }

--- a/doc/INSTALL.ZH.md
+++ b/doc/INSTALL.ZH.md
@@ -10,6 +10,8 @@
 
 ## 第二步
 
+修改eslint配置文件，如果你是在unix下开发，将规则`"linebreak-style: ["error","windows"]"`替换为`"linebreak-style: ["error","unix"]"`
+
 安装依赖, 推荐使用yarn `yarn` 或者 `npm install`
 
 ![](./screenshots/yarn.png)

--- a/doc/INSTALL.md
+++ b/doc/INSTALL.md
@@ -10,6 +10,8 @@ Clone the project to the local `git clone https://github.com/yinxin630/fiora.git
 
 ## Step 2
 
+modify eslint config, if your system is Unix, replace rule `"linebreak-style: ["error","windows"]"` as `"linebreak-style: ["error","unix"]"` 
+
 Installation dependencies, recommended yarn `yarn` or `npm install`
 
 ![](./screenshots/yarn.png)


### PR DESCRIPTION
windows下用vscode开发，eslint检测报错，补充`"linebreak-style: ["error","windows"]"`