### PR TITLE
为图片提供一个独立的端口设置

### DIFF
--- a/config/server.ts
+++ b/config/server.ts
@@ -10,6 +10,10 @@ export default {
     // service port
     port: options.port || env.Port || 9200,
 
+    // image port
+    /** 返回图片所使用的端口，通常与service port一致 */
+    imgPort: options.imgPort || env.ImgPort || 9200,      
+
     // mongodb address
     database: options.database || env.Database || 'mongodb://localhost:27017/fiora',
 

--- a/server/routes/system.ts
+++ b/server/routes/system.ts
@@ -170,7 +170,7 @@ export async function uploadFile(ctx) {
         );
         return {
             url: `${
-                process.env.NODE_ENV === 'production' ? '' : `http://${config.host}${config.port.toString() === '80' ? '' : `:${config.port}`}`
+                process.env.NODE_ENV === 'production' ? '' : `http://${config.host}${config.imgPort.toString() === '80' ? '' : `:${config.imgPort}`}`
             }/${ctx.data.fileName}`,
         };
     } catch (err) {

--- a/utils/commandOptions.ts
+++ b/utils/commandOptions.ts
@@ -12,6 +12,7 @@ const optionDefinitions = [
     { name: 'host', type: String },
     { name: 'port', type: Number },
     { name: 'administrator', type: String },
+    { name: 'imgPort', type: Number },
 ];
 
 interface CommandArgs {
@@ -26,6 +27,7 @@ interface CommandArgs {
     host: string;
     port: number;
     administrator: string;
+    imgPort: number;
 }
 
 const args: CommandArgs = commandLineArgs(optionDefinitions);


### PR DESCRIPTION
这个图片的端口设置专门为反向代理而加，方便在运行反向代理时对外使用同一端口。



PS： #89 的问题仍然存在，不过 #89 的使用方式似乎有些畸形，遂抛弃之。