### PR TITLE
fix: fix user info dialog will show close btn over large image

### DIFF
--- a/client/modules/InfoDialog.less
+++ b/client/modules/InfoDialog.less
@@ -42,6 +42,7 @@
     left: 220px;
     width: 300px;
     height: 300px;
+    z-index: 9999;
 
     @media @mobile {
         width: 180px;


### PR DESCRIPTION
Before: 

![image](https://user-images.githubusercontent.com/6964737/104095288-04f8f880-52d1-11eb-996b-eb319ba48ebb.png)

After:

![image](https://user-images.githubusercontent.com/6964737/104095279-fb6f9080-52d0-11eb-863c-df993cba47f3.png)
