### PR TITLE
Fix the error of invalid messageId

### DIFF
--- a/client/modules/Chat/Chat.tsx
+++ b/client/modules/Chat/Chat.tsx
@@ -83,7 +83,7 @@ function Chat() {
                     state.linkmans[state.focus].messages[messageKeys[messageKeys.length - 1]]._id;
                 if (lastMessageId !== lastMessageIdCache) {
                     lastMessageIdCache = lastMessageId;
-                    await updateHistory(state.user?._id, state.focus, lastMessageId);
+                    await updateHistory(state.focus, lastMessageId);
                 }
             }
         }

--- a/client/modules/Chat/MessageList.tsx
+++ b/client/modules/Chat/MessageList.tsx
@@ -54,7 +54,7 @@ function MessageList() {
         action.setLinkmanProperty(focus, 'unread', 0);
         const messageKeys = Object.keys(messages);
         if (messageKeys.length > 0) {
-            updateHistory(selfId, focus, messages[messageKeys[messageKeys.length - 1]]._id);
+            updateHistory(focus, messages[messageKeys[messageKeys.length - 1]]._id);
         }
     }
 

--- a/client/modules/FunctionBarAndLinkmanList/Linkman.tsx
+++ b/client/modules/FunctionBarAndLinkmanList/Linkman.tsx
@@ -9,7 +9,7 @@ import { isMobile } from '../../../utils/ua';
 
 import Style from './Linkman.less';
 import useAero from '../../hooks/useAero';
-import { useFocusLinkman, useSelfId, useStore } from '../../hooks/useStore';
+import { useFocusLinkman, useStore } from '../../hooks/useStore';
 import { updateHistory } from '../../service';
 
 interface LinkmanProps {
@@ -30,7 +30,6 @@ function Linkman(props: LinkmanProps) {
     const aero = useAero();
     const { linkmans } = useStore();
     const focusLinkman = useFocusLinkman();
-    const self = useSelfId();
 
     function formatTime() {
         const nowTime = new Date();
@@ -50,7 +49,7 @@ function Linkman(props: LinkmanProps) {
             if (messageKeys.length > 0) {
                 const lastMessageId =
                     focusLinkman.messages[messageKeys[messageKeys.length - 1]]._id;
-                updateHistory(self, focusLinkman._id, lastMessageId);
+                updateHistory(focusLinkman._id, lastMessageId);
             }
         }
 
@@ -61,7 +60,7 @@ function Linkman(props: LinkmanProps) {
             if (messageKeys.length > 0) {
                 const lastMessageId =
                 nextFocusLinkman.messages[messageKeys[messageKeys.length - 1]]._id;
-                updateHistory(self, nextFocusLinkman._id, lastMessageId);
+                updateHistory(nextFocusLinkman._id, lastMessageId);
             }
         }
 

--- a/client/service.ts
+++ b/client/service.ts
@@ -387,7 +387,7 @@ export async function getUserOnlineStatus(userId: string) {
     return res && res.isOnline;
 }
 
-export async function updateHistory(userId: string, linkmanId: string, messageId: string) {
-    const [, result] = await fetch('updateHistory', { userId, linkmanId, messageId });
+export async function updateHistory(linkmanId: string, messageId: string) {
+    const [, result] = await fetch('updateHistory', { linkmanId, messageId });
     return !!result;
 }


### PR DESCRIPTION
- The client may use temp messageId (messages that have not been sent) when calling `updateHistory`
- Should only be able to update its own history