### PR TITLE
Add rimraf package and ncp package to adapt to file operations in Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,9 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "jest": "^26.1.0",
     "lerna": "^4.0.0",
+    "ncp": "^2.0.0",
     "redis-mock": "^0.56.3",
+    "rimraf": "^5.0.5",
     "ts-jest": "^26.1.3",
     "ts-node": "^10.1.0",
     "typescript": "^3.8.2"

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "dev:web": "cross-env NODE_ENV=development DOTENV_CONFIG_PATH=../../.env webpack serve --config build/webpack.dev.js",
-    "build:web": "rm -rf dist && cross-env NODE_ENV=production DOTENV_CONFIG_PATH=../../.env webpack --config build/webpack.prod.js && cp -r -f dist/fiora/* ../server/public"
+    "build:web": "rimraf dist && cross-env NODE_ENV=production DOTENV_CONFIG_PATH=../../.env webpack --config build/webpack.prod.js && ncp dist/fiora/ ../server/public"
   },
   "dependencies": {
     "@fiora/assets": "^1.0.0",


### PR DESCRIPTION
Fixed an issue where build:web could not be used on the Windows side, using ncp and rimraf, fixed issues #548, #535